### PR TITLE
religion -> Religion in Druid skill options, fixed some attack entries

### DIFF
--- a/pub_20240917_PHB.js
+++ b/pub_20240917_PHB.js
@@ -1760,7 +1760,7 @@ legacyClassRefactor("druid", {
   die: 8,
   saves: ["Int", "Wis"],
   skillstxt: {
-    primary: "Choose 2: Arcana, Animal Handling, Insight, Medicine, Nature, Perception, religion, or Survival",
+    primary: "Choose 2: Arcana, Animal Handling, Insight, Medicine, Nature, Perception, Religion, or Survival",
   },
   armorProfs: {
     primary: [true, false, false, true],
@@ -13507,7 +13507,7 @@ WeaponsList["shocking grasp"] = {
   type: "Cantrip",
   damage: ["C", 8, "lightning"],
   range: "Melee",
-  description: "Advantage if target is wearing metal armor, target cannot take reactions until its next turn",
+  description: "Target cannot make opportunity attacks until its next turn",
   abilitytodamage: false
 };
 WeaponsList["sorcerous burst"] = {
@@ -13531,7 +13531,7 @@ WeaponsList["starry wisp"] = {
   type: "Cantrip",
   damage: ["C", 8, "radiant"],
   range: "60 ft",
-  description: "target emit dim light in a 10ft rad. can't benefit from Invis.",
+  description: "target emits dim light in a 10ft rad., can't benefit from Invis.",
   abilitytodamage: false
 };
 WeaponsList["toll the dead"] = {

--- a/pub_20250218_MM.js
+++ b/pub_20250218_MM.js
@@ -1499,7 +1499,7 @@ CreatureList["deer"] = {
 		range : "Melee (5 ft)",
 		description : "",
 	}],
-	wildshapeString : "Agile: The deer doens't provoke an Opportunity Attack when it moves out of an enemy's reach.",
+	wildshapeString : "Agile: The deer doesn't provoke an Opportunity Attack when it moves out of an enemy's reach.",
 };
 CreatureList["dire wolf"] = {
 	name : "Dire Wolf",

--- a/pub_20250218_MM.js
+++ b/pub_20250218_MM.js
@@ -2201,7 +2201,7 @@ CreatureList["giant lizard"] = {
 	traits : [{
 		name : "Spider Climb",
 		description : desc([
-			"The lizard can climb difficult urfaces, including along ceilings, without needing to make an ability check.",
+			"The lizard can climb difficult surfaces, including along ceilings, without needing to make an ability check.",
 		]),	
 	}],		
 	attacks : [{


### PR DESCRIPTION
Shocking Grasp and Starry Wisp where updated. Shocking Grasp was still based on the 2014 version of the spell, Starry Wisp had some minor phrasing things changed.